### PR TITLE
keywords.txt: replace spaces with TABs

### DIFF
--- a/dwenguino/libraries/Dwenguino/keywords.txt
+++ b/dwenguino/libraries/Dwenguino/keywords.txt
@@ -5,25 +5,26 @@
 ###################################
 # Datatypes (KEYWORD1)
 ###################################
-IOBoard	KEYWORD1
-Motor KEYWORD1
-SensorPanel KEYWORD1
+IOBoard		KEYWORD1
+Motor		KEYWORD1
+SensorPanel	KEYWORD1
 
 ###################################
 # Methods and Functions (KEYWORD2)
 ###################################
 initDwenguino	KEYWORD2
 
-readInputs KEYWORD2
-setOutputs KEYWORD2
+readInputs		KEYWORD2
+setOutputs		KEYWORD2
 
-backlightOn KEYWORD2
-backlightOff KEYWORD2
+backlightOn		KEYWORD2
+backlightOff	KEYWORD2
 
-setHeadlights KEYWORD2
-readSensor KEYWORD2
-powerLongRange KEYWORD2
+setHeadlights	KEYWORD2
+readSensor		KEYWORD2
+powerLongRange	KEYWORD2
 
-###################################
-# Constants (LITERAL1)
-###################################
+#######################################
+# Instances (KEYWORD2)
+#######################################
+dwenguinoLCD	KEYWORD2

--- a/dwenguino/libraries/Dwenguino/keywords.txt
+++ b/dwenguino/libraries/Dwenguino/keywords.txt
@@ -14,14 +14,14 @@ SensorPanel	KEYWORD1
 ###################################
 initDwenguino	KEYWORD2
 
-readInputs		KEYWORD2
-setOutputs		KEYWORD2
+readInputs	KEYWORD2
+setOutputs	KEYWORD2
 
-backlightOn		KEYWORD2
+backlightOn	KEYWORD2
 backlightOff	KEYWORD2
 
 setHeadlights	KEYWORD2
-readSensor		KEYWORD2
+readSensor	KEYWORD2
 powerLongRange	KEYWORD2
 
 #######################################


### PR DESCRIPTION
For some reasons some of the methods are not highlighted. Replacing spaces with TABS fixed this for me. It also says that on the manual. I also remove the section literals as it was empty.